### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 Watches a designated node in Zookeeper for data or member changes. 
 Implements a Watch class which can be used as a decorator to trigger functions when changes are detected on a specified node in Zookeeper.
 
-[![Latest Version](https://pypip.in/version/Zookeeper-Watcher/badge.png)]
+[![Latest Version](https://img.shields.io/pypi/v/Zookeeper-Watcher.svg)]
 (https://pypi.python.org/pypi/Zookeeper-Watcher/)
-[![Downloads](https://pypip.in/download/Zookeeper-Watcher/badge.png)]
+[![Downloads](https://img.shields.io/pypi/dm/Zookeeper-Watcher.svg)]
 (https://pypi.python.org/pypi/Zookeeper-Watcher/)
-[![Download format](https://pypip.in/format/Zookeeper-Watcher/badge.png)]
+[![Download format](https://img.shields.io/pypi/format/Zookeeper-Watcher.svg)]
 (https://pypi.python.org/pypi/Zookeeper-Watcher/)
-[![License](https://pypip.in/license/Zookeeper-Watcher/badge.png)]
+[![License](https://img.shields.io/pypi/l/Zookeeper-Watcher.svg)]
 (https://pypi.python.org/pypi/Zookeeper-Watcher/)
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20zookeeper-watcher))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `zookeeper-watcher`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.